### PR TITLE
Fix strdup implementation

### DIFF
--- a/etc/strdup.c
+++ b/etc/strdup.c
@@ -6,7 +6,7 @@ char *strdup(const char *str)
 {
     char *dup;
     size_t length = strlen(str) + 1;
-    if((dup = malloc(length)) == NULL) {
+    if((dup = malloc(length)) != NULL) {
         memcpy(dup, str, length);
     }
     return dup;


### PR DESCRIPTION
`if` condition in the given strdup was wrong.
memcpy should be done when malloc returns non-null value

For reference, here is the strdup inplementation in glibc -

```
/* Duplicate S, returning an identical malloc'd string.  */
char *
strdup (const char *s)
{
  size_t len = strlen (s) + 1;
  void *new = malloc (len);
  if (new == NULL)
    return NULL;
  return (char *) memcpy (new, s, len);
}
```